### PR TITLE
Strip units in Solinst csv reader for the 1xxxxxx series

### DIFF
--- a/hydsensread/file_reader/compagny_file_reader/solinst_file_reader.py
+++ b/hydsensread/file_reader/compagny_file_reader/solinst_file_reader.py
@@ -143,8 +143,9 @@ class LEVSolinstFileReader(TimeSeriesFileReader):
                 _date = lines.split(":")[1].replace(" ", "")
             if re.search(r"^time.*", lines, re.IGNORECASE):
                 _time = lines.split(" :")[1].replace(" ", "")
-        to_datetime = datetime.datetime.strptime("{} {}".format(_date, _time),
-                                                 self.MONTH_S_DAY_S_YEAR_HMS_DATE_STRING_FORMAT)
+        to_datetime = datetime.datetime.strptime(
+            "{} {}".format(_date, _time),
+            self.MONTH_S_DAY_S_YEAR_HMS_DATE_STRING_FORMAT)
         return to_datetime
 
     def _update_header_lentgh(self):

--- a/hydsensread/file_reader/compagny_file_reader/solinst_file_reader.py
+++ b/hydsensread/file_reader/compagny_file_reader/solinst_file_reader.py
@@ -414,7 +414,7 @@ class CSVSolinstFileReader(TimeSeriesFileReader):
                 else:
                     # For Solinst Gold logger files.
                     units = self.file_content[i + 2][0]
-                self._params_dict[param][self.UNIT] = units
+                self._params_dict[param][self.UNIT] = units.strip()
 
     def _get_data(self):
         for parameter in list(self._params_dict.keys()):

--- a/hydsensread/tests/test_solinst_reader.py
+++ b/hydsensread/tests/test_solinst_reader.py
@@ -38,6 +38,8 @@ def test_solinst_levelogger_edge(test_files_dir, testfile):
     assert records.iloc[-1].iloc[0] == 1906.33
     assert records.iloc[-1].iloc[1] == 8.275
 
+    assert list(records.columns) == ["LEVEL_cm", "TEMPERATURE_°C"]
+
     sites = solinst_file.sites
     assert sites.instrument_serial_number == "2010143"
     assert sites.project_name == "03040018"
@@ -59,6 +61,8 @@ def test_solinst_levelogger_edge_lev(test_files_dir):
     assert records.index.tolist()[-1] == Timestamp('2017-06-22 15:15:00')
     assert records.iloc[-1].iloc[0] == 10.1788
     assert records.iloc[-1].iloc[1] == 11.844
+
+    assert list(records.columns) == ["LEVEL_m", "TEMPERATURE_°C"]
 
     sites = solinst_file.sites
     assert sites.instrument_serial_number == "2041929"
@@ -88,6 +92,8 @@ def test_solinst_levelogger_gold(test_files_dir, testfile):
     assert records.index.tolist()[-1] == Timestamp('2017-11-21 09:30:00')
     assert records.iloc[-1].iloc[0] == 912.308
     assert records.iloc[-1].iloc[1] == 9.204
+
+    assert list(records.columns) == ["LEVEL_cm", "TEMPERATURE_Deg C"]
 
     sites = solinst_file.sites
     assert sites.instrument_serial_number == "1062280"


### PR DESCRIPTION
This is required to removed some tabs that are present in the header of the file.

- [x] Fix the bug
- [x] Expand the tests