### PR TITLE
PR: Add .spyproject folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ ENV/
 
 # Spyder project settings
 .spyderproject
+.spyproject
 
 # Rope project settings
 .ropeproject


### PR DESCRIPTION
The default folder name for Spyder projects changed in the latest version, so we need to add it to the gitignore.