### PR TITLE
PR: Refactoring of solinst readers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 
 [![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![pypi version](https://img.shields.io/pypi/v/HydroSensorReader.svg)](https://pypi.org/project/HydroSensorReader/)
 
 [![Build Status](https://travis-ci.org/cgq-qgc/HydroSensorReader.svg?branch=master)](https://travis-ci.org/cgq-qgc/HydroSensorReader)
 [![Coverage Status](https://coveralls.io/repos/github/cgq-qgc/HydroSensorReader/badge.svg)](https://coveralls.io/github/cgq-qgc/HydroSensorReader)

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,9 +36,9 @@ r = hsr.DATCampbellCRFileReader(file_path)
 # - Supported extension : '.xls', '.xlsx'
 r = hsr.XLSHannaFileReader(file_path)
 
-# read Solinst Levelogger and Barologger files
+# Read Solinst Levelogger and Barologger files
 # - Supported extension : '.lev', '.xle', '.csv'
-r = hsr.SolinstFileReader(file_path)
+r = hsr.read_solinst_file(file_path)
 
 # Plot the results with
 r.plot()

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ r = hsr.XLSHannaFileReader(file_path)
 
 # Read Solinst Levelogger and Barologger files
 # - Supported extension : '.lev', '.xle', '.csv'
-r = hsr.read_solinst_file(file_path)
+r = hsr.solinst_reader(file_path)
 
 # Plot the results with
 r.plot()

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ r = hsr.XLSHannaFileReader(file_path)
 
 # Read Solinst Levelogger and Barologger files
 # - Supported extension : '.lev', '.xle', '.csv'
-r = hsr.solinst_reader(file_path)
+r = hsr.SolinstFileReader(file_path)
 
 # Plot the results with
 r.plot()

--- a/hydsensread/__init__.py
+++ b/hydsensread/__init__.py
@@ -7,8 +7,6 @@
 # Licensed under the terms of the MIT License.
 # -----------------------------------------------------------------------------
 
-from .file_reader.compagny_file_reader.solinst_file_reader import (
-    solinst_reader)
 from .file_reader import (
     SolinstFileReader, DATCampbellCRFileReader,  XLSHannaFileReader,
     XSLMaxxamFileReader)

--- a/hydsensread/__init__.py
+++ b/hydsensread/__init__.py
@@ -1,14 +1,17 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__author__ = 'Laptop'
-__date__ = '2018-04-15'
-__description__ = " "
-__version__ = '1.0'
+# -----------------------------------------------------------------------------
+# Copyright © HydroSensorReader Project Contributors
+# https://github.com/cgq-qgc/HydroSensorReader
+#
+# This file is part of HydroSensorReader.
+# Licensed under the terms of the MIT License.
+# -----------------------------------------------------------------------------
 
-from .file_reader import SolinstFileReader, \
-    DATCampbellCRFileReader, \
-    XLSHannaFileReader, \
-    XSLMaxxamFileReader
+from .file_reader.compagny_file_reader.solinst_file_reader import (
+    read_solinst_file)
+from .file_reader import (
+    DATCampbellCRFileReader,  XLSHannaFileReader,
+    XSLMaxxamFileReader)
 from .file_reader.web_page_reader.gnb_core_samples_web_scraper import GNBCoreSamplesDataFactory
 from .file_reader.web_page_reader.gnb_core_samples_web_scraper import GNBCoreSamplesListWebScrapper
 from .file_reader.web_page_reader.gnb_core_samples_web_scraper import GNBCoreSamplesNTSMapSearchWebScrapper

--- a/hydsensread/__init__.py
+++ b/hydsensread/__init__.py
@@ -8,9 +8,9 @@
 # -----------------------------------------------------------------------------
 
 from .file_reader.compagny_file_reader.solinst_file_reader import (
-    read_solinst_file)
+    solinst_reader)
 from .file_reader import (
-    DATCampbellCRFileReader,  XLSHannaFileReader,
+    SolinstFileReader, DATCampbellCRFileReader,  XLSHannaFileReader,
     XSLMaxxamFileReader)
 from .file_reader.web_page_reader.gnb_core_samples_web_scraper import GNBCoreSamplesDataFactory
 from .file_reader.web_page_reader.gnb_core_samples_web_scraper import GNBCoreSamplesListWebScrapper

--- a/hydsensread/file_reader/__init__.py
+++ b/hydsensread/file_reader/__init__.py
@@ -8,10 +8,9 @@ __version__ = '1.0'
 from hydsensread.file_reader.abstract_file_reader import AbstractFileReader, GeochemistryFileReader, \
     TimeSeriesFileReader, \
     TimeSeriesGeochemistryFileReader
-from .compagny_file_reader import SolinstFileReader, \
-    DATCampbellCRFileReader, \
-    XLSHannaFileReader, \
-    XSLMaxxamFileReader
+from .compagny_file_reader import (
+    CSVSolinstFileReader, LEVSolinstFileReader, XLESolinstFileReader,
+    DATCampbellCRFileReader, XLSHannaFileReader, XSLMaxxamFileReader)
 try:
     from .web_page_reader import GNBWaterQualityStation, GNBCoreSamplesNTSMapSearchWebScrapper
 except:

--- a/hydsensread/file_reader/__init__.py
+++ b/hydsensread/file_reader/__init__.py
@@ -5,13 +5,14 @@ __date__ = '2017-07-09$'
 __description__ = " "
 __version__ = '1.0'
 
-from hydsensread.file_reader.abstract_file_reader import AbstractFileReader, GeochemistryFileReader, \
-    TimeSeriesFileReader, \
-    TimeSeriesGeochemistryFileReader
+from hydsensread.file_reader.abstract_file_reader import (
+    AbstractFileReader, GeochemistryFileReader, TimeSeriesFileReader,
+    TimeSeriesGeochemistryFileReader)
 from .compagny_file_reader import (
-    CSVSolinstFileReader, LEVSolinstFileReader, XLESolinstFileReader,
-    DATCampbellCRFileReader, XLSHannaFileReader, XSLMaxxamFileReader)
+    SolinstFileReader, DATCampbellCRFileReader, XLSHannaFileReader,
+    XSLMaxxamFileReader)
 try:
-    from .web_page_reader import GNBWaterQualityStation, GNBCoreSamplesNTSMapSearchWebScrapper
+    from .web_page_reader import (GNBWaterQualityStation,
+                                  GNBCoreSamplesNTSMapSearchWebScrapper)
 except:
     pass

--- a/hydsensread/file_reader/compagny_file_reader/__init__.py
+++ b/hydsensread/file_reader/compagny_file_reader/__init__.py
@@ -7,7 +7,8 @@ __version__ = '0.0.1'
 from .campbell_cr_file_reader import DATCampbellCRFileReader
 from .hanna_file_reader import XLSHannaFileReader
 from .maxxam_file_reader import XSLMaxxamFileReader
-from .solinst_file_reader import CSVSolinstFileReader, LEVSolinstFileReader, XLESolinstFileReader, SolinstFileReader
+from .solinst_file_reader import (
+    CSVSolinstFileReader, LEVSolinstFileReader, XLESolinstFileReader)
 from .what_csv_file_reader import WhatMeteorologicalDataFileReader
 from .what_csv_file_reader import WhatStreamAndLevelDataFileReader
 from .what_csv_file_reader import WhatWaterLevelDataFileReader

--- a/hydsensread/file_reader/compagny_file_reader/__init__.py
+++ b/hydsensread/file_reader/compagny_file_reader/__init__.py
@@ -8,7 +8,8 @@ from .campbell_cr_file_reader import DATCampbellCRFileReader
 from .hanna_file_reader import XLSHannaFileReader
 from .maxxam_file_reader import XSLMaxxamFileReader
 from .solinst_file_reader import (
-    CSVSolinstFileReader, LEVSolinstFileReader, XLESolinstFileReader)
+    SolinstFileReader, CSVSolinstFileReader, LEVSolinstFileReader,
+    XLESolinstFileReader)
 from .what_csv_file_reader import WhatMeteorologicalDataFileReader
 from .what_csv_file_reader import WhatStreamAndLevelDataFileReader
 from .what_csv_file_reader import WhatWaterLevelDataFileReader

--- a/hydsensread/file_reader/compagny_file_reader/solinst_file_reader.py
+++ b/hydsensread/file_reader/compagny_file_reader/solinst_file_reader.py
@@ -1,22 +1,26 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from matplotlib import pyplot as plt
+# -----------------------------------------------------------------------------
+# Copyright © HydroSensorReader Project Contributors
+# https://github.com/cgq-qgc/HydroSensorReader
+#
+# This file is part of HydroSensorReader.
+# Licensed under the terms of the MIT License.
+# -----------------------------------------------------------------------------
 
-__author__ = 'Laptop$'
-__date__ = '2017-07-16$'
-__description__ = " "
-__version__ = '1.3'
-
+# ---- Standard imports
 import datetime
 import re
 import warnings
 from collections import defaultdict
 from typing import List, Tuple
+import os.path as osp
 
+# ---- Third party imports
+from matplotlib import pyplot as plt
 from pandas import Timestamp
 
+# ---- Local imports
 from hydsensread.file_reader.abstract_file_reader import (
-    TimeSeriesFileReader, date_list, LineDefinition)
 
 
 class SolinstFileReader(TimeSeriesFileReader):
@@ -46,6 +50,7 @@ class SolinstFileReader(TimeSeriesFileReader):
         else:
             warnings.warn("Unknown file extension for this compagny")
         self._site_of_interest = self.__main_reader._site_of_interest
+    TimeSeriesFileReader, LineDefinition)
 
     def read_file(self):
         self.__main_reader.read_file()

--- a/hydsensread/file_reader/compagny_file_reader/solinst_file_reader.py
+++ b/hydsensread/file_reader/compagny_file_reader/solinst_file_reader.py
@@ -24,9 +24,27 @@ from hydsensread.file_reader.abstract_file_reader import (
     TimeSeriesFileReader, LineDefinition)
 
 
-def read_solinst_file(file_path, wait_read=False):
+def solinst_reader(file_path, wait_read=False):
     """
     Return a Solinst reader object appropriate to the given file type.
+
+    Parameters
+    ----------
+    file_path : str, path object
+        A valid string path or path object to a Solinst '.lev', '.xle', or
+        '.csv' level or baro level data file.
+    wait_read : bool
+        A boolean that indicates wheter the content of the file should be
+        read on instantiation of the reader. If 'False', use the
+        'read_file' method of the reader to read the content of the file
+        when needed.
+
+    Returns
+    -------
+    TimeSeriesFileReader
+        A time series file reader that can read Solinst '.lev', '.xle', or
+        '.csv' level or baro logger data files.
+
     """
     if not osp.isfile(file_path) or not osp.exists(file_path):
         raise ValueError("The path given doesn't point to an existing file.")
@@ -43,7 +61,14 @@ def read_solinst_file(file_path, wait_read=False):
         warnings.warn("Unknown file extension for this compagny")
 
 
-class SolinstFileReader(TimeSeriesFileReader):
+def SolinstFileReader(file_path, wait_read=False):
+    msg = ("SolinstFileReader is deprecated for removal in 1.8. "
+           "Use the function 'solinst_reader' instead.")
+    warnings.warn(msg, UserWarning)
+    return solinst_reader(file_path, wait_read=False)
+
+
+class SolinstFileReaderBase(TimeSeriesFileReader):
     def __init__(self, *args, **kargs):
         super().__init__(*args, **kargs)
 
@@ -85,7 +110,7 @@ class SolinstFileReader(TimeSeriesFileReader):
         return fig, axis
 
 
-class LEVSolinstFileReader(SolinstFileReader):
+class LEVSolinstFileReader(SolinstFileReaderBase):
     DATA_CHANNEL_STRING = ".*CHANNEL {} from data header.*"
 
     def __init__(self, file_path: str = None, header_length: int = 10,
@@ -202,7 +227,7 @@ class LEVSolinstFileReader(SolinstFileReader):
             self._site_of_interest.create_time_serie(parameter, parametere_unit, self._date_list, values)
 
 
-class XLESolinstFileReader(SolinstFileReader):
+class XLESolinstFileReader(SolinstFileReaderBase):
     CHANNEL_DATA_HEADER = "Ch{}_data_header"
 
     def __init__(self, file_path: str = None, header_length: int = 10,
@@ -315,7 +340,7 @@ class XLESolinstFileReader(SolinstFileReader):
                                   values)
 
 
-class CSVSolinstFileReader(SolinstFileReader):
+class CSVSolinstFileReader(SolinstFileReaderBase):
     UNIT = 'unit'
     PARAMETER_COL_INDEX = 'col_index'
 
@@ -420,8 +445,7 @@ if __name__ == '__main__':
     dirname = osp.join(dirname, 'tests', 'files')
     filename = '1XXXXXX_solinst_levelogger_gold_testfile.csv'
 
-    reader = read_solinst_file(osp.join(dirname, filename), wait_read=False)
-    reader.read_file()
+    reader = solinst_reader(osp.join(dirname, filename))
     print(reader.records)
     print(reader.sites)
 

--- a/hydsensread/file_reader/compagny_file_reader/solinst_file_reader.py
+++ b/hydsensread/file_reader/compagny_file_reader/solinst_file_reader.py
@@ -24,51 +24,52 @@ from hydsensread.file_reader.abstract_file_reader import (
     TimeSeriesFileReader, LineDefinition)
 
 
-def solinst_reader(file_path, wait_read=False):
+class SolinstFileReader(object):
     """
-    Return a Solinst reader object appropriate to the given file type.
-
-    Parameters
-    ----------
-    file_path : str, path object
-        A valid string path or path object to a Solinst '.lev', '.xle', or
-        '.csv' level or baro level data file.
-    wait_read : bool
-        A boolean that indicates wheter the content of the file should be
-        read on instantiation of the reader. If 'False', use the
-        'read_file' method of the reader to read the content of the file
-        when needed.
-
-    Returns
-    -------
-    TimeSeriesFileReader
-        A time series file reader that can read Solinst '.lev', '.xle', or
-        '.csv' level or baro logger data files.
-
+    A reader for Solinst '.lev', '.xle', or '.csv' files.
     """
-    if not osp.isfile(file_path) or not osp.exists(file_path):
-        raise ValueError("The path given doesn't point to an existing file.")
-    root, ext = osp.splitext(file_path)
-    ext = ext[1:]
 
-    if ext in TimeSeriesFileReader.CSV_FILES_TYPES:
-        return CSVSolinstFileReader(file_path, wait_read=wait_read)
-    elif ext == 'lev':
-        return LEVSolinstFileReader(file_path, wait_read=wait_read)
-    elif ext == 'xle':
-        return XLESolinstFileReader(file_path, wait_read=wait_read)
-    else:
-        warnings.warn("Unknown file extension for this compagny")
+    def __new__(cls, file_path, wait_read=False):
+        """
+        Parameters
+        ----------
+        file_path : str, path object
+            A valid string path or path object to a Solinst '.lev', '.xle', or
+            '.csv' level or baro level data file.
+        wait_read : bool
+            A boolean that indicates wheter the content of the file should be
+            read on instantiation of the reader. If 'False', use the
+            'read_file' method of the reader to read the content of the file
+            when needed.
 
+        Returns
+        -------
+        TimeSeriesFileReader
+            A time series file reader that can read Solinst '.lev', '.xle', or
+            '.csv' level or baro logger data files.
 
-def SolinstFileReader(file_path, wait_read=False):
-    msg = ("SolinstFileReader is deprecated for removal in 1.8. "
-           "Use the function 'solinst_reader' instead.")
-    warnings.warn(msg, UserWarning)
-    return solinst_reader(file_path, wait_read=False)
+        """
+        if not osp.isfile(file_path) or not osp.exists(file_path):
+            raise ValueError("The path given doesn't point to an "
+                             "existing file.")
+
+        root, ext = osp.splitext(file_path)
+        ext = ext[1:]
+        if ext in TimeSeriesFileReader.CSV_FILES_TYPES:
+            return CSVSolinstFileReader(file_path, wait_read=wait_read)
+        elif ext == 'lev':
+            return LEVSolinstFileReader(file_path, wait_read=wait_read)
+        elif ext == 'xle':
+            return XLESolinstFileReader(file_path, wait_read=wait_read)
+        else:
+            warnings.warn("Unknown file extension for this compagny")
 
 
 class SolinstFileReaderBase(TimeSeriesFileReader):
+    """
+    Base class for Solinst file readers.
+    """
+
     def __init__(self, *args, **kargs):
         super().__init__(*args, **kargs)
 
@@ -77,11 +78,13 @@ class SolinstFileReaderBase(TimeSeriesFileReader):
             Tuple[plt.Figure, List[plt.Axes]]:
         """
         Plot function overriding the TimeSeriesFileReader method.
-        :param other_axis: if other axis needs to be added to the plot, use this parameter
-        :param reformat_temperature: if the temperature axis needs to be reformated or not.
-        :param args:
-        :param kwargs:
-        :return:
+
+        Parameters
+        ----------
+        param other_axis :
+            if other axis needs to be added to the plot, use this parameter
+        param reformat_temperature :
+            if the temperature axis needs to be reformated or not.
         """
         temperature_line_def = LineDefinition('TEMPERATURE_°C', 'red')
         temperature_values = self.records['TEMPERATURE_°C']
@@ -445,7 +448,7 @@ if __name__ == '__main__':
     dirname = osp.join(dirname, 'tests', 'files')
     filename = '1XXXXXX_solinst_levelogger_gold_testfile.csv'
 
-    reader = solinst_reader(osp.join(dirname, filename))
+    reader = SolinstFileReader(osp.join(dirname, filename))
     print(reader.records)
     print(reader.sites)
 

--- a/hydsensread/file_reader/compagny_file_reader/solinst_file_reader.py
+++ b/hydsensread/file_reader/compagny_file_reader/solinst_file_reader.py
@@ -416,33 +416,12 @@ class CSVSolinstFileReader(SolinstFileReader):
 
 
 if __name__ == '__main__':
-    import os
-    import matplotlib.pyplot as plt
+    dirname = osp.dirname(osp.dirname(osp.dirname(__file__)))
+    dirname = osp.join(dirname, 'tests', 'files')
+    filename = '1XXXXXX_solinst_levelogger_gold_testfile.csv'
 
-    path = os.getcwd()
-    while os.path.split(path)[1] != "hydsensread":
-        path = os.path.split(path)[0]
-    file_loc = os.path.join(path, 'file_example')
+    reader = read_solinst_file(osp.join(dirname, filename), wait_read=False)
+    reader.read_file()
+    print(reader.records)
+    print(reader.sites)
 
-    teste_all = True
-    file_loc = "C:\\Users\\Laptop\\Documents\\McCully_slugTest_XM20180608"
-    if teste_all:
-        # file_name = "F21_logger_20160224_20160621.csv"
-        file_name = "PO-12_slug_3_XM20180608.lev"
-        # file_name = "slug_PO-05_20160729_1600.csv"
-        # file_name = "2029499_F7_NordChamp_PL20150925_2015_09_25.xle"
-        # file_name = "2041929_PO-06_XM20170307_2017_03_07.lev"
-        # file_name = "2056794_PO-05_baro_CB20161109_2016_11_09.lev"
-        file_location = os.path.join(file_loc, file_name)
-        print(file_location)
-        # t = ET.parse(open(file_location))
-        # root = t.getroot()
-        # print(root.find('Instrument_info_data_header').find('Location').text)
-        solinst_file = SolinstFileReader(file_location)
-        print(solinst_file.file_reader)
-        solinst_file.read_file()
-        print(solinst_file.sites)
-        print(solinst_file.records)
-        # print(len([i for i in solinst_file.records.dtypes.index if 'kpa' in i.lower()]) > 0)
-        solinst_file.plot(reformat_temperature=False)
-        plt.show(block=True)

--- a/hydsensread/tests/test_solinst_reader.py
+++ b/hydsensread/tests/test_solinst_reader.py
@@ -1,4 +1,11 @@
 # -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright © HydroSensorReader Project Contributors
+# https://github.com/cgq-qgc/HydroSensorReader
+#
+# This file is part of HydroSensorReader.
+# Licensed under the terms of the MIT License.
+# -----------------------------------------------------------------------------
 
 # ---- Standard imports
 import os
@@ -25,7 +32,7 @@ def test_files_dir():
      "2XXXXXX_solinst_levelogger_edge_testfile.xle"])
 def test_solinst_levelogger_edge(test_files_dir, testfile):
     """Test reading Solinst Edge Levelogger files."""
-    solinst_file = hsr.SolinstFileReader(osp.join(test_files_dir, testfile))
+    solinst_file = hsr.read_solinst_file(osp.join(test_files_dir, testfile))
 
     records = solinst_file.records
     assert len(records) == 19484
@@ -49,7 +56,7 @@ def test_solinst_levelogger_edge(test_files_dir, testfile):
 def test_solinst_levelogger_edge_lev(test_files_dir):
     """Test reading Solinst Edge Levelogger .lev files."""
     testfile = "2XXXXXX_solinst_levelogger_edge_testfile.lev"
-    solinst_file = hsr.SolinstFileReader(osp.join(test_files_dir, testfile))
+    solinst_file = hsr.read_solinst_file(osp.join(test_files_dir, testfile))
 
     records = solinst_file.records
     assert len(records) == 10258
@@ -80,7 +87,7 @@ def test_solinst_levelogger_gold(test_files_dir, testfile):
 
     Regression test for Issue #26.
     """
-    solinst_file = hsr.SolinstFileReader(osp.join(test_files_dir, testfile))
+    solinst_file = hsr.read_solinst_file(osp.join(test_files_dir, testfile))
 
     records = solinst_file.records
     assert len(records) == 19475
@@ -112,7 +119,7 @@ def test_solinst_colon_decimalsep(test_files_dir, testfile):
 
     Regression test for Issue #33.
     """
-    solinst_file = hsr.SolinstFileReader(osp.join(test_files_dir, testfile))
+    solinst_file = hsr.read_solinst_file(osp.join(test_files_dir, testfile))
 
     records = solinst_file.records
     assert len(records) == 10

--- a/hydsensread/tests/test_solinst_reader.py
+++ b/hydsensread/tests/test_solinst_reader.py
@@ -32,7 +32,7 @@ def test_files_dir():
      "2XXXXXX_solinst_levelogger_edge_testfile.xle"])
 def test_solinst_levelogger_edge(test_files_dir, testfile):
     """Test reading Solinst Edge Levelogger files."""
-    solinst_file = hsr.read_solinst_file(osp.join(test_files_dir, testfile))
+    solinst_file = hsr.solinst_reader(osp.join(test_files_dir, testfile))
 
     records = solinst_file.records
     assert len(records) == 19484
@@ -56,7 +56,7 @@ def test_solinst_levelogger_edge(test_files_dir, testfile):
 def test_solinst_levelogger_edge_lev(test_files_dir):
     """Test reading Solinst Edge Levelogger .lev files."""
     testfile = "2XXXXXX_solinst_levelogger_edge_testfile.lev"
-    solinst_file = hsr.read_solinst_file(osp.join(test_files_dir, testfile))
+    solinst_file = hsr.solinst_reader(osp.join(test_files_dir, testfile))
 
     records = solinst_file.records
     assert len(records) == 10258
@@ -87,7 +87,7 @@ def test_solinst_levelogger_gold(test_files_dir, testfile):
 
     Regression test for Issue #26.
     """
-    solinst_file = hsr.read_solinst_file(osp.join(test_files_dir, testfile))
+    solinst_file = hsr.solinst_reader(osp.join(test_files_dir, testfile))
 
     records = solinst_file.records
     assert len(records) == 19475
@@ -119,7 +119,7 @@ def test_solinst_colon_decimalsep(test_files_dir, testfile):
 
     Regression test for Issue #33.
     """
-    solinst_file = hsr.read_solinst_file(osp.join(test_files_dir, testfile))
+    solinst_file = hsr.solinst_reader(osp.join(test_files_dir, testfile))
 
     records = solinst_file.records
     assert len(records) == 10

--- a/hydsensread/tests/test_solinst_reader.py
+++ b/hydsensread/tests/test_solinst_reader.py
@@ -32,7 +32,7 @@ def test_files_dir():
      "2XXXXXX_solinst_levelogger_edge_testfile.xle"])
 def test_solinst_levelogger_edge(test_files_dir, testfile):
     """Test reading Solinst Edge Levelogger files."""
-    solinst_file = hsr.solinst_reader(osp.join(test_files_dir, testfile))
+    solinst_file = hsr.SolinstFileReader(osp.join(test_files_dir, testfile))
 
     records = solinst_file.records
     assert len(records) == 19484
@@ -56,7 +56,7 @@ def test_solinst_levelogger_edge(test_files_dir, testfile):
 def test_solinst_levelogger_edge_lev(test_files_dir):
     """Test reading Solinst Edge Levelogger .lev files."""
     testfile = "2XXXXXX_solinst_levelogger_edge_testfile.lev"
-    solinst_file = hsr.solinst_reader(osp.join(test_files_dir, testfile))
+    solinst_file = hsr.SolinstFileReader(osp.join(test_files_dir, testfile))
 
     records = solinst_file.records
     assert len(records) == 10258
@@ -87,7 +87,7 @@ def test_solinst_levelogger_gold(test_files_dir, testfile):
 
     Regression test for Issue #26.
     """
-    solinst_file = hsr.solinst_reader(osp.join(test_files_dir, testfile))
+    solinst_file = hsr.SolinstFileReader(osp.join(test_files_dir, testfile))
 
     records = solinst_file.records
     assert len(records) == 19475
@@ -119,7 +119,7 @@ def test_solinst_colon_decimalsep(test_files_dir, testfile):
 
     Regression test for Issue #33.
     """
-    solinst_file = hsr.solinst_reader(osp.join(test_files_dir, testfile))
+    solinst_file = hsr.SolinstFileReader(osp.join(test_files_dir, testfile))
 
     records = solinst_file.records
     assert len(records) == 10


### PR DESCRIPTION
The goal is to remove an extra layer of code that was present for the Solinst readers by adding a new function `read_solinst_file` that returns a Solinst reader object appropriate to the given file type.

This is the strategy that is used by many packages, such as Pandas, so I guess this is not going to be too much confusing.

This should make the code easier to understand and make the maintenance and development of the Solinst readers easier by making the inheritance tree a little bit cleaner and easier to follow.