### PR TITLE
PR: Don't undo altitude or zero point offset systematically

### DIFF
--- a/hydsensread/file_reader/compagny_file_reader/solinst_file_reader.py
+++ b/hydsensread/file_reader/compagny_file_reader/solinst_file_reader.py
@@ -142,7 +142,6 @@ class SolinstFileReaderBase(TimeSeriesFileReader):
         self._date_list = self._get_date_list()
         self._get_data()
         self._format_data_units()
-        self._undo_zero_point_offset()
 
     # ---- Private API
     def _format_data_units(self):
@@ -181,7 +180,7 @@ class SolinstFileReaderBase(TimeSeriesFileReader):
                     self.sites.records[column] = (
                         self.sites.records[column] - 0.12 * altitude)
 
-    def _undo_zero_point_offset(self):
+    def undo_zero_point_offset(self):
         """
         Undo the zero point offset applied to readings made by level and baro
         loggers of the Gold series (1xxxxxx) and older.

--- a/hydsensread/file_reader/compagny_file_reader/solinst_file_reader.py
+++ b/hydsensread/file_reader/compagny_file_reader/solinst_file_reader.py
@@ -143,7 +143,6 @@ class SolinstFileReaderBase(TimeSeriesFileReader):
         self._get_data()
         self._format_data_units()
         self._undo_zero_point_offset()
-        self._undo_altitude_correction()
 
     # ---- Private API
     def _format_data_units(self):
@@ -157,7 +156,7 @@ class SolinstFileReaderBase(TimeSeriesFileReader):
                 columns_map[column] = column
         self.records.rename(columns_map, axis='columns', inplace=True)
 
-    def _undo_altitude_correction(self):
+    def undo_altitude_correction(self):
         """
         Undo the automatic compensation for elevation applied to readings made
         by level and baro loggers of the Gold series (1xxxxxx) and older.

--- a/hydsensread/file_reader/compagny_file_reader/tests/test_solinst_reader.py
+++ b/hydsensread/file_reader/compagny_file_reader/tests/test_solinst_reader.py
@@ -102,12 +102,22 @@ def test_solinst_levelogger_gold(test_files_dir, testfile):
     assert list(records.columns) == ["LEVEL_cm", "TEMPERATURE_degC"]
 
     assert records.index[0] == Timestamp('2017-05-02 13:00:00')
-    assert records.iloc[0].iloc[0] == 923.561 - (0.12 * 42) + 950
+    assert records.iloc[0].iloc[0] == 923.561
     assert records.iloc[0].iloc[1] == 8.936
 
     assert records.index[-1] == Timestamp('2017-05-04 14:45:00')
-    assert records.iloc[-1].iloc[0] == 934.8801 - (0.12 * 42) + 950
+    assert records.iloc[-1].iloc[0] == 934.8801
     assert records.iloc[-1].iloc[1] == 8.914
+
+    # Test undo altitude correction.
+    solinst_file.undo_altitude_correction()
+    assert records.iloc[-1].iloc[0] == 934.8801 - (0.12 * 42)
+    assert records.iloc[-1].iloc[0] == 934.8801 - (0.12 * 42)
+
+    # Test undo zero point offset.
+    solinst_file.undo_zero_point_offset()
+    assert records.iloc[0].iloc[0] == 923.561 - (0.12 * 42) + 950
+    assert records.iloc[-1].iloc[0] == 934.8801 - (0.12 * 42) + 950
 
     assert solinst_file.plot()
 
@@ -133,9 +143,19 @@ def test_solinst_levelogger_M5(test_files_dir, testfile):
     assert list(records.columns) == ["LEVEL_cm"]
 
     assert records.index[0] == Timestamp('2016-11-04 13:00:00')
-    assert records.iloc[0].iloc[0] == 314.0 - (0.12 * 170) + 950
+    assert records.iloc[0].iloc[0] == 314.0
 
     assert records.index[-1] == Timestamp('2016-11-06 14:45:00')
+    assert records.iloc[-1].iloc[0] == 317.5
+
+    # Test undo altitude correction.
+    solinst_file.undo_altitude_correction()
+    assert records.iloc[0].iloc[0] == 314.0 - (0.12 * 170)
+    assert records.iloc[-1].iloc[0] == 317.5 - (0.12 * 170)
+
+    # Test undo zero point offset.
+    solinst_file.undo_zero_point_offset()
+    assert records.iloc[0].iloc[0] == 314.0 - (0.12 * 170) + 950
     assert records.iloc[-1].iloc[0] == 317.5 - (0.12 * 170) + 950
 
     assert solinst_file.plot()


### PR DESCRIPTION
The altitude and zero point offset corrections that were introduced in PR #51 and PR #43 are very useful when dealing with uncompensated raw level data or raw baro data, but it is not correct when dealing with level data that were compensated with the Solinst software, because these offsets were cancelled by the compensation.

Also, there is no way to determine whether the level data were compensated or not from the header of the file, so we cannot implement a logic to undo the above offsets automatically only when the data are either uncompensated level data or baro data. In more recent version of the Solinst software, the information regarding data compensation is added to the header of the files. But in order to remain backward compatible with older files, we need to assume that this information is not available.

So, in order to take that into account, this PR remove the systematic undoing of altitude and zero point offset. So it is up to the user to do it explicitly if needed. The method to undo these offsets were made public, so that they can be accessed more easily by the user.